### PR TITLE
When started with --run flag exit with code from run_installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -249,6 +249,7 @@ elif has_command_line_switch? "run"; then
 
   # Automatic installation.
   run_installation
+  exit $?
 
 else
 


### PR DESCRIPTION
This allows scripts that call the installer with the `--run` flag to check the exit code of the installation.